### PR TITLE
fix openai string too long: truncate geojson properties

### DIFF
--- a/app/clients/openai_client.py
+++ b/app/clients/openai_client.py
@@ -110,7 +110,10 @@ def get_properties(geojson: dict) -> str:
     # remove duplicated and empty props
     deduplicated_properties = set(str(prop) for prop in properties if prop)
     props_str = ', '.join(deduplicated_properties) or 'not available'
-    # Construct and return the result string with all unique, deduplicated properties
+    max_properties_length = 2000
+    if len(props_str) > max_properties_length:
+        props_str = props_str[:max_properties_length] + '...'
+    # Construct and return the result string with all unique and truncated properties
     return f'(input GeoJSON properties: {props_str})'
 
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced property extraction functionality to manage output length, ensuring strings do not exceed 2000 characters.
	- Added truncation with an ellipsis for clarity when properties are too long.

- **Bug Fixes**
	- Improved robustness of property handling to prevent issues related to excessively long outputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->