### PR TITLE
add maxZoom to quotients in mcda suggestions api

### DIFF
--- a/app/clients/insights_api_client.py
+++ b/app/clients/insights_api_client.py
@@ -55,6 +55,7 @@ axis_graphql = """
             quotients {
                 name
                 label
+                maxZoom
                 emoji
                 description
                 copyrights


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced a new field `maxZoom` in the `quotients` structure of the GraphQL `getAxes` query, enhancing the data returned.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->