### PR TITLE
Fix UTC timestamp handling in analytics

### DIFF
--- a/app/clients/insights_api_client.py
+++ b/app/clients/insights_api_client.py
@@ -323,7 +323,13 @@ def value_to_str(x: float, entry: dict, sigma=False):
             and x < 2000000000):
         if entry['calculation'] == 'stddev':
             return str(timedelta(seconds=int(x)))
-        return datetime.fromtimestamp(int(x), tz=timezone.utc).replace(tzinfo=None).isoformat()
+        # Timestamp values are delivered in UTC. Include the 'Z' suffix to
+        # explicitly denote the UTC 00 offset.
+        return (
+            datetime.fromtimestamp(int(x), tz=timezone.utc)
+            .isoformat()
+            .replace('+00:00', 'Z')
+        )
 
     unit_str = unit_to_str(entry, sigma)
     # Format the value to be more readable, especially handling scientific notation.

--- a/tests/test_analytics.py
+++ b/tests/test_analytics.py
@@ -69,7 +69,7 @@ class TestAnalytics(unittest.TestCase):
             'reference_area_sigma': 0,
         }]
 
-        expected = 'mean of 🐱 OSM last edit is 2024-04-25T05:02:54 (globally 2020-09-14T19:51:05, 1.00 sigma)'
+        expected = 'mean of 🐱 OSM last edit is 2024-04-25T05:02:54Z (globally 2020-09-14T19:51:05Z, 1.00 sigma)'
         actual = to_readable_sentence(selected_area_data, world_data)[0]
         self.assertEqual(expected, actual)
 


### PR DESCRIPTION
## Summary
- parse UNIX timestamps as UTC in `insights_api_client`
- update tests to match UTC-based formatting

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_683f41ed451883249100e3d839d1790c

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved consistency in timestamp formatting by ensuring all Unix timestamps are converted using UTC instead of the local timezone.

- **Tests**
  - Updated test cases to reflect the new UTC-based timestamp formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->