### PR TITLE
Fix trailing dash in image tags

### DIFF
--- a/.github/workflows/deploy_stage.yml
+++ b/.github/workflows/deploy_stage.yml
@@ -67,7 +67,7 @@ jobs:
         run: |
           IMAGE_TAG="${{ github.ref_name }}.${{ steps.get_cloned.outputs.sha }}.${{ github.run_attempt }}"
           # sanitize branch name to produce a valid docker tag
-          IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/ ' '--' | tr -cs 'A-Za-z0-9_.-' '-' )"
+          IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/ ' '--' | tr -cs 'A-Za-z0-9_.-' '-' | sed 's/-$//')"
           IMAGE_TAG="$(echo "$IMAGE_TAG" | sed 's/^[^A-Za-z0-9]*//')"
           echo "image_tag=${IMAGE_TAG}" >> $GITHUB_OUTPUT
           echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_ENV

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -23,7 +23,7 @@ jobs:
         run: |
           IMAGE_TAG="${{ github.ref_name }}.${{ steps.get-cloned.outputs.SHA }}.${{ github.run_attempt }}"
           # replace slashes and invalid characters with hyphens
-          IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/ ' '--' | tr -cs 'A-Za-z0-9_.-' '-' )"
+          IMAGE_TAG="$(echo "$IMAGE_TAG" | tr '/ ' '--' | tr -cs 'A-Za-z0-9_.-' '-' | sed 's/-$//')"
           # docker tags must start with alphanumeric character
           IMAGE_TAG="$(echo "$IMAGE_TAG" | sed 's/^[^A-Za-z0-9]*//')"
           echo "IMAGE_TAG=$IMAGE_TAG" >> "$GITHUB_ENV"


### PR DESCRIPTION
## Summary
- sanitize image tags to remove trailing dash in both GH actions

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'app')*

------
https://chatgpt.com/codex/tasks/task_e_6849baaf66088324b85623dcbc82e1bd

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Improved Docker image tag formatting in deployment workflows to prevent tags from ending with a hyphen.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->